### PR TITLE
feat: add lockFilePath and agent to output

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const LOCK_FILE_NAMES = {
 
 const NPM_COMMANDS = {
   name: 'npm',
+  agent: 'npm',
   install: 'npm install',
   'frozen-install': 'npm ci',
   'global-install': 'npm install -g',
@@ -21,6 +22,7 @@ const NPM_COMMANDS = {
 
 const YARN_COMMANDS = {
   name: 'yarn',
+  agent: 'yarn',
   install: 'yarn install',
   'frozen-install': 'yarn install --frozen-lockfile',
   'global-install': 'yarn global add',
@@ -35,6 +37,7 @@ const YARN_COMMANDS = {
 
 const YARN_BERRY_COMMANDS = {
   ...YARN_COMMANDS,
+  agent: 'yarnBerry',
   'frozen-install': 'yarn install --immutable',
   // yarn 2+ has no global install command
   'global-install': 'npm install -g',
@@ -44,6 +47,7 @@ const YARN_BERRY_COMMANDS = {
 
 const PNPM_COMMANDS = {
   name: 'pnpm',
+  agent: 'pnpm',
   install: 'pnpm install',
   'frozen-install': 'pnpm install --frozen-lockfile',
   'global-install': 'pnpm add -g',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import path from 'path';
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { PackageManager } from './types';
+import { LOCK_FILE_NAMES } from './constants';
 
 export function* lookUp(dir: string = process.cwd()): Generator<string> {
   let directory = path.resolve(dir);
@@ -51,4 +52,17 @@ export function getPackageManagerFromPackageJson(filePath: string): PackageManag
   } catch {
     return undefined;
   }
+}
+
+export function getLockFilePath(directory: string) {
+  for (const d of lookUp(directory)) {
+    for (const lockFile of Object.keys(LOCK_FILE_NAMES)) {
+      const lockFilePath = path.join(d, lockFile);
+      if (existsSync(lockFilePath)) {
+        return path.join(d, lockFile);
+      }
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
This PR adds the following to the pm-detect output:

- `lockFilePath`: walks up the tree looking for the closed lock file based on the resolved package manager name.
- `agent`: additional "name" allowing users to check for `yarnBerry`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.0--canary.7.17289953624.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install pm-detect@0.3.0--canary.7.17289953624.0
  # or 
  yarn add pm-detect@0.3.0--canary.7.17289953624.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
