### PR TITLE
fix: pnpm use exec for local exec command

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,7 +56,7 @@ const PNPM_COMMANDS = {
   update: 'pnpm update',
   run: 'pnpm run',
   exec: 'pnpm dlx',
-  'exec-local': 'pnpm dlx',
+  'exec-local': 'pnpm exec',
 } as const;
 
 export const PACKAGE_MANAGER_COMMANDS = {


### PR DESCRIPTION
PNPM commands incorrectly use `[dlx](https://pnpm.io/cli/dlx)` when it should use `[exec](https://pnpm.io/cli/exec)` for local exec command.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.1--canary.11.20192998946.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install pm-detect@0.3.1--canary.11.20192998946.0
  # or 
  yarn add pm-detect@0.3.1--canary.11.20192998946.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
