### PR TITLE
feat: generate typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "bin": {
     "pm-detect": "dist/cli.js"
   },
-  "main": "dist/lib.js",
-  "types": "dist/types/lib.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/types/index.d.ts",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json && chmod +x dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "pm-detect": "dist/cli.js"
   },
   "main": "dist/lib.js",
+  "types": "dist/types/lib.d.ts",
   "scripts": {
     "test": "vitest",
     "build": "tsc -p tsconfig.build.json && chmod +x dist/cli.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { detect, getCommands } from './lib';
+export { getLockFilePath } from './utils';

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,7 +4,6 @@ import { LOCK_FILE_NAMES } from './constants';
 import { existsSync } from 'fs';
 import path from 'path';
 import { PackageManager, DetectOptions } from './types';
-export { getLockFilePath } from './utils';
 
 export function detect(options: DetectOptions = {}): PackageManager | undefined {
   const strategies = options.strategies ?? ['packageJson', 'lockFile', 'userAgent'];

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -4,6 +4,7 @@ import { LOCK_FILE_NAMES } from './constants';
 import { existsSync } from 'fs';
 import path from 'path';
 import { PackageManager, DetectOptions } from './types';
+export { getLockFilePath } from './utils';
 
 export function detect(options: DetectOptions = {}): PackageManager | undefined {
   const strategies = options.strategies ?? ['packageJson', 'lockFile', 'userAgent'];

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": ["./tsconfig.json"],
+  "compilerOptions": {
+    "declaration": true
+  },
   "exclude": ["node_modules", "${configDir}/dist", "${configDir}/**/*.test.ts*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": ["./tsconfig.json"],
   "compilerOptions": {
-    "declaration": true
+    "declaration": true,
+    "declarationDir": "dist/types"
   },
   "exclude": ["node_modules", "${configDir}/dist", "${configDir}/**/*.test.ts*"]
 }


### PR DESCRIPTION
Package is missing typescript declaration files. This PR adds them to dist.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.0--canary.12.21389574240.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install pm-detect@0.4.0--canary.12.21389574240.0
  # or 
  yarn add pm-detect@0.4.0--canary.12.21389574240.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
