### PR TITLE
fix: gate userAgent fallback on strategies arg

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ The detection pipeline lives in three files; understanding how they compose is t
 
 **Order matters.** Strategies short-circuit on first hit per directory, but the outer directory loop also short-circuits — meaning a deeper `package.json` with no `packageManager` field will *not* fall through to a lockfile in a parent directory unless `lockFile` runs in the same iteration. Both loops are intentional and tested (see "traverse up directory tree" and "prioritize package.json" cases in `src/lib.test.ts`).
 
-`userAgent` as a fallback is also applied *after* the directory walk completes, in case nothing was found in any directory. This is separate from including `userAgent` in the strategy list.
+`userAgent` as a fallback is also applied *after* the directory walk completes, in case nothing was found in any directory. The post-walk fallback runs only when `'userAgent'` is in the strategies list (the default). Callers that pass an explicit list excluding it get no fallback — `detect()` returns `undefined` instead.
 
 ### Commands resolution
 

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import path from 'path';
 import { detect, getCommands } from './lib';
 import { PACKAGE_MANAGER_COMMANDS } from './constants';
@@ -129,6 +131,28 @@ describe('lib', () => {
         name: 'npm',
         version: '8.19.2',
       });
+    });
+
+    it('uses userAgent strategy exclusively when other strategies are excluded', () => {
+      process.env.npm_config_user_agent = 'yarn/1.22.19 npm/? node/v18.17.0 darwin x64';
+
+      const result = detect({
+        cwd: path.resolve('test/fixtures/npm-project'),
+        strategies: ['userAgent'],
+      });
+
+      expect(result).toEqual({ name: 'yarn', version: '1.22.19' });
+    });
+
+    it('does not fall back to userAgent when strategies excludes it', () => {
+      process.env.npm_config_user_agent = 'yarn/1.22.19 npm/? node/v18.17.0 darwin x64';
+      const tmp = mkdtempSync(path.join(tmpdir(), 'pm-detect-'));
+      try {
+        const result = detect({ cwd: tmp, strategies: ['packageJson', 'lockFile'] });
+        expect(result).toBeUndefined();
+      } finally {
+        rmSync(tmp, { recursive: true });
+      }
     });
   });
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -38,13 +38,14 @@ export function detect(options: DetectOptions = {}): PackageManager | undefined 
     }
   }
 
-  // Fallback to user agent if no package manager found in files
-  const userAgentResult = getPackageManagerFromUserAgent();
-  if (userAgentResult) {
-    return {
-      name: userAgentResult.name as PackageManager['name'],
-      version: userAgentResult.version,
-    };
+  if (strategies.includes('userAgent')) {
+    const userAgentResult = getPackageManagerFromUserAgent();
+    if (userAgentResult) {
+      return {
+        name: userAgentResult.name as PackageManager['name'],
+        version: userAgentResult.version,
+      };
+    }
   }
 
   return undefined;


### PR DESCRIPTION
## Summary

`detect()` always ran the `npm_config_user_agent` fallback after the directory walk, regardless of what `options.strategies` the caller passed. Calling `detect({ strategies: ['packageJson', 'lockFile'] })` would still read the user agent env var when no file was found — the strategies arg wasn't load-bearing.

This change wraps the post-walk fallback in `if (strategies.includes('userAgent'))`. Default behaviour is unchanged (the default strategies list includes `'userAgent'`); explicit caller lists are now respected.

## Test plan

- [x] Added test `does not fall back to userAgent when strategies excludes it` — fails on `main` (returns yarn), passes after the fix (returns undefined). Uses `os.mkdtempSync` for a guaranteed empty walk since `lookUp()` would otherwise reach this repo's own `package.json`.
- [x] Added test `uses userAgent strategy exclusively when other strategies are excluded` — regression guard for the inverse case.
- [x] `npm run typecheck && npm run lint && npm test -- --run && npm run build` all clean (34/34 tests).
- [x] Updated `CLAUDE.md` to reflect the new gating semantics in the strategies-and-traversal note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)