### PR TITLE
feat: add installState detection strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,10 @@ vite.config.ts.timestamp-*
 
 # Claude Code local session artifacts
 .claude/
+
+# Allow install-state marker files under test fixtures
+!test/fixtures/**/node_modules
+!test/fixtures/**/node_modules/**
+!test/fixtures/**/.pnp.*
+!test/fixtures/**/.yarn
+!test/fixtures/**/.yarn/**

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ npx pm-detect --working-dir /path/to/project
 
 ### `--strategies <strategies>`
 
-Specifies a comma-separated list of detection strategies to use. The default order is `packageJson,installState,lockFile,userAgent` — strategies run in the order given and the first match wins. Available strategies:
+Specifies a comma-separated list of detection strategies to use. The default order is `packageJson,installState,lockFile,userAgent` — the file-based strategies (`packageJson`, `installState`, `lockFile`) run in the order given against each directory while walking up from the working directory, and the first match wins. `userAgent` is a post-walk fallback: it only runs if no file-based strategy matched in any directory, regardless of where it appears in the list. Available strategies:
 
 - `packageJson` - Detect from `package.json`'s `packageManager` field (most authoritative; recommended)
 - `installState` - Detect from metadata each manager writes during install: `node_modules/.modules.yaml` (pnpm, with version), `node_modules/.yarn-state.yml` or `.pnp.cjs` (yarn berry; version recovered from `.yarn/releases/yarn-*.cjs`), `node_modules/.yarn-integrity` (yarn classic), `node_modules/.package-lock.json` (npm)
 - `lockFile` - Detect from lock file presence (`bun.lock`, `bun.lockb`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`)
-- `userAgent` - Detect from the `npm_config_user_agent` environment variable
+- `userAgent` - Detect from the `npm_config_user_agent` environment variable (post-walk fallback only)
 
 `installState` is preferred over `lockFile` by default because it reflects what is actually installed, which is more authoritative than a lockfile that may lag behind a manager switch.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Package Manager Detect
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This package includes a bin which can be used to detect the current node package manager a node project uses and it's associated commands.
@@ -46,18 +48,21 @@ npx pm-detect --working-dir /path/to/project
 
 ### `--strategies <strategies>`
 
-Specifies a comma-separated list of detection strategies to use. Available strategies are:
+Specifies a comma-separated list of detection strategies to use. The default order is `packageJson,installState,lockFile,userAgent` — strategies run in the order given and the first match wins. Available strategies:
 
-- `packageJson` - Detect from package.json's packageManager field (recommended)
-- `lockFile` - Detect from lock file presence (bun.lock, bun.lockb, package-lock.json, yarn.lock, pnpm-lock.yaml)
-- `userAgent` - Detect from npm_config_user_agent environment variable
+- `packageJson` - Detect from `package.json`'s `packageManager` field (most authoritative; recommended)
+- `installState` - Detect from metadata each manager writes during install: `node_modules/.modules.yaml` (pnpm, with version), `node_modules/.yarn-state.yml` or `.pnp.cjs` (yarn berry; version recovered from `.yarn/releases/yarn-*.cjs`), `node_modules/.yarn-integrity` (yarn classic), `node_modules/.package-lock.json` (npm)
+- `lockFile` - Detect from lock file presence (`bun.lock`, `bun.lockb`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`)
+- `userAgent` - Detect from the `npm_config_user_agent` environment variable
+
+`installState` is preferred over `lockFile` by default because it reflects what is actually installed, which is more authoritative than a lockfile that may lag behind a manager switch.
 
 ```bash
 # Use only package.json detection
 npx pm-detect --strategies packageJson
 
 # Use multiple strategies in a specific order
-npx pm-detect --strategies packageJson,lockFile,userAgent
+npx pm-detect --strategies packageJson,installState,lockFile,userAgent
 ```
 
 ### `--help`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,7 +86,7 @@ function main() {
 
   if (parsedArgs.strategies) {
     // Validate strategies
-    const validStrategies = ['packageJson', 'lockFile', 'userAgent'];
+    const validStrategies = ['packageJson', 'installState', 'lockFile', 'userAgent'];
     const invalidStrategies = parsedArgs.strategies.filter((s) => !validStrategies.includes(s));
 
     if (invalidStrategies.length > 0) {

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -201,6 +201,21 @@ describe('lib', () => {
           rmSync(tmp, { recursive: true });
         }
       });
+
+      it('default order prefers installState over a conflicting lockfile', () => {
+        const result = detect({ cwd: path.resolve('test/fixtures/install-state-vs-lockfile-conflict') });
+
+        expect(result).toEqual({ name: 'pnpm', version: '8.6.0' });
+      });
+
+      it('respects caller-supplied order when lockFile precedes installState', () => {
+        const result = detect({
+          cwd: path.resolve('test/fixtures/install-state-vs-lockfile-conflict'),
+          strategies: ['lockFile', 'installState'],
+        });
+
+        expect(result).toEqual({ name: 'npm' });
+      });
     });
   });
 

--- a/src/lib.test.ts
+++ b/src/lib.test.ts
@@ -154,6 +154,54 @@ describe('lib', () => {
         rmSync(tmp, { recursive: true });
       }
     });
+
+    describe('installState strategy', () => {
+      it('detects pnpm with version from node_modules/.modules.yaml', () => {
+        const result = detect({
+          cwd: path.resolve('test/fixtures/pnpm-installed-project'),
+          strategies: ['installState'],
+        });
+
+        expect(result).toEqual({ name: 'pnpm', version: '8.6.0' });
+      });
+
+      it('detects npm from node_modules/.package-lock.json', () => {
+        const result = detect({
+          cwd: path.resolve('test/fixtures/npm-installed-project'),
+          strategies: ['installState'],
+        });
+
+        expect(result).toEqual({ name: 'npm' });
+      });
+
+      it('detects yarn classic from node_modules/.yarn-integrity', () => {
+        const result = detect({
+          cwd: path.resolve('test/fixtures/yarn-classic-installed-project'),
+          strategies: ['installState'],
+        });
+
+        expect(result).toEqual({ name: 'yarn' });
+      });
+
+      it('detects yarnBerry from .pnp.cjs and reads version from .yarn/releases', () => {
+        const result = detect({
+          cwd: path.resolve('test/fixtures/yarn-berry-pnp-project'),
+          strategies: ['installState'],
+        });
+
+        expect(result).toEqual({ name: 'yarnBerry', version: '4.0.2' });
+      });
+
+      it('returns undefined when only a package.json is present', () => {
+        const tmp = mkdtempSync(path.join(tmpdir(), 'pm-detect-'));
+        try {
+          const result = detect({ cwd: tmp, strategies: ['installState'] });
+          expect(result).toBeUndefined();
+        } finally {
+          rmSync(tmp, { recursive: true });
+        }
+      });
+    });
   });
 
   describe('getCommands', () => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import { PackageManager, DetectOptions } from './types';
 
 export function detect(options: DetectOptions = {}): PackageManager | undefined {
-  const strategies = options.strategies ?? ['packageJson', 'lockFile', 'userAgent'];
+  const strategies = options.strategies ?? ['packageJson', 'installState', 'lockFile', 'userAgent'];
   for (const directory of lookUp(options.cwd)) {
     for (const strategy of strategies) {
       switch (strategy) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,10 @@
 import { PACKAGE_MANAGER_COMMANDS } from './constants';
-import { getPackageManagerFromPackageJson, getPackageManagerFromUserAgent, lookUp } from './utils';
+import {
+  getPackageManagerFromInstallState,
+  getPackageManagerFromPackageJson,
+  getPackageManagerFromUserAgent,
+  lookUp,
+} from './utils';
 import { LOCK_FILE_NAMES } from './constants';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -31,6 +36,14 @@ export function detect(options: DetectOptions = {}): PackageManager | undefined 
                 name,
               };
             }
+          }
+          break;
+        }
+
+        case 'installState': {
+          const result = getPackageManagerFromInstallState(directory);
+          if (result) {
+            return result;
           }
           break;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,5 +7,5 @@ export type PackageManager = {
 
 export type DetectOptions = {
   cwd?: string;
-  strategies?: ('packageJson' | 'lockFile' | 'userAgent')[];
+  strategies?: ('packageJson' | 'installState' | 'lockFile' | 'userAgent')[];
 };

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
 import { readFileSync } from 'fs';
-import { lookUp, getPackageManagerFromUserAgent, getPackageManagerFromPackageJson } from './utils';
+import {
+  lookUp,
+  getPackageManagerFromUserAgent,
+  getPackageManagerFromPackageJson,
+  parsePnpmVersionFromModulesYaml,
+} from './utils';
 
 // Mock fs module
 vi.mock('fs', () => ({
@@ -226,6 +231,32 @@ describe('utils', () => {
         name: 'invalid-format',
         version: undefined,
       });
+    });
+  });
+
+  describe('parsePnpmVersionFromModulesYaml', () => {
+    it('extracts the version from a packageManager: pnpm@X.Y.Z line', () => {
+      const yaml = ['layoutVersion: 5', 'packageManager: pnpm@8.6.0', 'storeDir: /tmp/store'].join('\n');
+
+      expect(parsePnpmVersionFromModulesYaml(yaml)).toBe('8.6.0');
+    });
+
+    it('returns undefined when the packageManager field is missing', () => {
+      const yaml = ['layoutVersion: 5', 'storeDir: /tmp/store'].join('\n');
+
+      expect(parsePnpmVersionFromModulesYaml(yaml)).toBeUndefined();
+    });
+
+    it('tolerates trailing whitespace on the line', () => {
+      const yaml = 'packageManager: pnpm@9.1.2   \nstoreDir: /tmp/store';
+
+      expect(parsePnpmVersionFromModulesYaml(yaml)).toBe('9.1.2');
+    });
+
+    it('does not match non-pnpm managers', () => {
+      const yaml = 'packageManager: npm@10.0.0';
+
+      expect(parsePnpmVersionFromModulesYaml(yaml)).toBeUndefined();
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -294,10 +294,9 @@ describe('utils', () => {
     });
 
     it('returns the first matching release when multiple exist', () => {
-      mockReaddirSync.mockReturnValue([
-        'yarn-3.6.4.cjs',
-        'yarn-4.0.2.cjs',
-      ] as unknown as ReturnType<typeof readdirSync>);
+      mockReaddirSync.mockReturnValue(['yarn-3.6.4.cjs', 'yarn-4.0.2.cjs'] as unknown as ReturnType<
+        typeof readdirSync
+      >);
 
       expect(getYarnBerryVersion('/repo')).toBe('3.6.4');
     });
@@ -375,9 +374,7 @@ describe('utils', () => {
     });
 
     it('prefers pnpm over npm when both markers exist (specificity)', () => {
-      mockExistsSync.mockImplementation(
-        markersExist('node_modules/.modules.yaml', 'node_modules/.package-lock.json')
-      );
+      mockExistsSync.mockImplementation(markersExist('node_modules/.modules.yaml', 'node_modules/.package-lock.json'));
       mockReadFileSync.mockReturnValue('packageManager: pnpm@8.6.0\n');
 
       expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'pnpm', version: '8.6.0' });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -293,12 +293,28 @@ describe('utils', () => {
       expect(getYarnBerryVersion('/repo')).toBeUndefined();
     });
 
-    it('returns the first matching release when multiple exist', () => {
+    it('returns the highest semver when multiple releases exist', () => {
       mockReaddirSync.mockReturnValue(['yarn-3.6.4.cjs', 'yarn-4.0.2.cjs'] as unknown as ReturnType<
         typeof readdirSync
       >);
 
-      expect(getYarnBerryVersion('/repo')).toBe('3.6.4');
+      expect(getYarnBerryVersion('/repo')).toBe('4.0.2');
+    });
+
+    it('does not depend on readdirSync ordering', () => {
+      mockReaddirSync.mockReturnValue(['yarn-4.0.2.cjs', 'yarn-3.6.4.cjs'] as unknown as ReturnType<
+        typeof readdirSync
+      >);
+
+      expect(getYarnBerryVersion('/repo')).toBe('4.0.2');
+    });
+
+    it('prefers a stable release over a prerelease of the same version', () => {
+      mockReaddirSync.mockReturnValue(['yarn-4.1.0-rc.1.cjs', 'yarn-4.1.0.cjs'] as unknown as ReturnType<
+        typeof readdirSync
+      >);
+
+      expect(getYarnBerryVersion('/repo')).toBe('4.1.0');
     });
   });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -332,7 +332,11 @@ describe('utils', () => {
     const mockReaddirSync = vi.mocked(readdirSync);
 
     function markersExist(...suffixes: string[]) {
-      return (p: unknown) => suffixes.some((s) => String(p).endsWith(s));
+      const normalize = (s: string) => s.replace(/\\/g, '/');
+      return (p: unknown) => {
+        const normalized = normalize(String(p));
+        return suffixes.some((s) => normalized.endsWith(normalize(s)));
+      };
     }
 
     beforeEach(() => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
-import { readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import {
   lookUp,
   getPackageManagerFromUserAgent,
   getPackageManagerFromPackageJson,
+  getPackageManagerFromInstallState,
   getYarnBerryVersion,
   parsePnpmVersionFromModulesYaml,
 } from './utils';
@@ -299,6 +300,93 @@ describe('utils', () => {
       ] as unknown as ReturnType<typeof readdirSync>);
 
       expect(getYarnBerryVersion('/repo')).toBe('3.6.4');
+    });
+  });
+
+  describe('getPackageManagerFromInstallState', () => {
+    const mockExistsSync = vi.mocked(existsSync);
+    const mockReadFileSync = vi.mocked(readFileSync);
+    const mockReaddirSync = vi.mocked(readdirSync);
+
+    function markersExist(...suffixes: string[]) {
+      return (p: unknown) => suffixes.some((s) => String(p).endsWith(s));
+    }
+
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(false);
+    });
+
+    it('detects pnpm with version from .modules.yaml', () => {
+      mockExistsSync.mockImplementation(markersExist('node_modules/.modules.yaml'));
+      mockReadFileSync.mockReturnValue('packageManager: pnpm@8.6.0\n');
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'pnpm', version: '8.6.0' });
+    });
+
+    it('detects pnpm without version when packageManager field is absent', () => {
+      mockExistsSync.mockImplementation(markersExist('node_modules/.modules.yaml'));
+      mockReadFileSync.mockReturnValue('layoutVersion: 5\n');
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'pnpm' });
+    });
+
+    it('detects pnpm even when .modules.yaml read throws', () => {
+      mockExistsSync.mockImplementation(markersExist('node_modules/.modules.yaml'));
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('EACCES');
+      });
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'pnpm' });
+    });
+
+    it('detects yarnBerry via .yarn-state.yml with version from .yarn/releases', () => {
+      mockExistsSync.mockImplementation(markersExist('node_modules/.yarn-state.yml'));
+      mockReaddirSync.mockReturnValue(['yarn-4.0.2.cjs'] as unknown as ReturnType<typeof readdirSync>);
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'yarnBerry', version: '4.0.2' });
+    });
+
+    it('detects yarnBerry via .pnp.cjs at the directory root', () => {
+      mockExistsSync.mockImplementation(markersExist('/.pnp.cjs'));
+      mockReaddirSync.mockReturnValue(['yarn-3.6.4.cjs'] as unknown as ReturnType<typeof readdirSync>);
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'yarnBerry', version: '3.6.4' });
+    });
+
+    it('returns yarnBerry without version when .yarn/releases is missing', () => {
+      mockExistsSync.mockImplementation(markersExist('/.pnp.cjs'));
+      mockReaddirSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'yarnBerry' });
+    });
+
+    it('detects yarn classic from .yarn-integrity', () => {
+      mockExistsSync.mockImplementation(markersExist('node_modules/.yarn-integrity'));
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'yarn' });
+    });
+
+    it('detects npm from .package-lock.json', () => {
+      mockExistsSync.mockImplementation(markersExist('node_modules/.package-lock.json'));
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'npm' });
+    });
+
+    it('prefers pnpm over npm when both markers exist (specificity)', () => {
+      mockExistsSync.mockImplementation(
+        markersExist('node_modules/.modules.yaml', 'node_modules/.package-lock.json')
+      );
+      mockReadFileSync.mockReturnValue('packageManager: pnpm@8.6.0\n');
+
+      expect(getPackageManagerFromInstallState('/repo')).toEqual({ name: 'pnpm', version: '8.6.0' });
+    });
+
+    it('returns undefined when no markers exist', () => {
+      mockExistsSync.mockReturnValue(false);
+
+      expect(getPackageManagerFromInstallState('/repo')).toBeUndefined();
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,16 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'path';
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync } from 'fs';
 import {
   lookUp,
   getPackageManagerFromUserAgent,
   getPackageManagerFromPackageJson,
+  getYarnBerryVersion,
   parsePnpmVersionFromModulesYaml,
 } from './utils';
 
 // Mock fs module
 vi.mock('fs', () => ({
+  existsSync: vi.fn(),
   readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
 }));
 
 describe('utils', () => {
@@ -257,6 +260,45 @@ describe('utils', () => {
       const yaml = 'packageManager: npm@10.0.0';
 
       expect(parsePnpmVersionFromModulesYaml(yaml)).toBeUndefined();
+    });
+  });
+
+  describe('getYarnBerryVersion', () => {
+    const mockReaddirSync = vi.mocked(readdirSync);
+
+    it('returns the semver from a yarn-X.Y.Z.cjs release file', () => {
+      mockReaddirSync.mockReturnValue(['yarn-4.0.2.cjs'] as unknown as ReturnType<typeof readdirSync>);
+
+      expect(getYarnBerryVersion('/repo')).toBe('4.0.2');
+    });
+
+    it('handles prerelease tags in the version', () => {
+      mockReaddirSync.mockReturnValue(['yarn-4.1.0-rc.1.cjs'] as unknown as ReturnType<typeof readdirSync>);
+
+      expect(getYarnBerryVersion('/repo')).toBe('4.1.0-rc.1');
+    });
+
+    it('returns undefined when .yarn/releases is missing', () => {
+      mockReaddirSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      expect(getYarnBerryVersion('/repo')).toBeUndefined();
+    });
+
+    it('returns undefined when no entry matches yarn-<semver>.cjs', () => {
+      mockReaddirSync.mockReturnValue(['plugin-foo.cjs', 'README.md'] as unknown as ReturnType<typeof readdirSync>);
+
+      expect(getYarnBerryVersion('/repo')).toBeUndefined();
+    });
+
+    it('returns the first matching release when multiple exist', () => {
+      mockReaddirSync.mockReturnValue([
+        'yarn-3.6.4.cjs',
+        'yarn-4.0.2.cjs',
+      ] as unknown as ReturnType<typeof readdirSync>);
+
+      expect(getYarnBerryVersion('/repo')).toBe('3.6.4');
     });
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -316,6 +316,14 @@ describe('utils', () => {
 
       expect(getYarnBerryVersion('/repo')).toBe('4.1.0');
     });
+
+    it('compares numeric prerelease identifiers numerically (rc.10 > rc.2)', () => {
+      mockReaddirSync.mockReturnValue(['yarn-4.1.0-rc.2.cjs', 'yarn-4.1.0-rc.10.cjs'] as unknown as ReturnType<
+        typeof readdirSync
+      >);
+
+      expect(getYarnBerryVersion('/repo')).toBe('4.1.0-rc.10');
+    });
   });
 
   describe('getPackageManagerFromInstallState', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,14 @@ export function getPackageManagerFromPackageJson(filePath: string): PackageManag
   }
 }
 
+export function parsePnpmVersionFromModulesYaml(contents: string): string | undefined {
+  const match = /^packageManager:\s*pnpm@(\S+?)\s*$/m.exec(contents);
+  if (!match) {
+    return undefined;
+  }
+  return match[1];
+}
+
 export function getLockFilePath(directory: string) {
   for (const d of lookUp(directory)) {
     for (const lockFile of Object.keys(LOCK_FILE_NAMES)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,6 +62,40 @@ export function parsePnpmVersionFromModulesYaml(contents: string): string | unde
   return match[1];
 }
 
+export function getPackageManagerFromInstallState(directory: string): PackageManager | undefined {
+  const nodeModules = path.join(directory, 'node_modules');
+
+  if (existsSync(path.join(nodeModules, '.modules.yaml'))) {
+    let version: string | undefined;
+    try {
+      version = parsePnpmVersionFromModulesYaml(readFileSync(path.join(nodeModules, '.modules.yaml'), 'utf-8'));
+    } catch {
+      // file unreadable; presence alone is enough to identify pnpm
+    }
+    return version ? { name: 'pnpm', version } : { name: 'pnpm' };
+  }
+
+  if (existsSync(path.join(nodeModules, '.yarn-state.yml'))) {
+    const version = getYarnBerryVersion(directory);
+    return version ? { name: 'yarnBerry', version } : { name: 'yarnBerry' };
+  }
+
+  if (existsSync(path.join(directory, '.pnp.cjs'))) {
+    const version = getYarnBerryVersion(directory);
+    return version ? { name: 'yarnBerry', version } : { name: 'yarnBerry' };
+  }
+
+  if (existsSync(path.join(nodeModules, '.yarn-integrity'))) {
+    return { name: 'yarn' };
+  }
+
+  if (existsSync(path.join(nodeModules, '.package-lock.json'))) {
+    return { name: 'npm' };
+  }
+
+  return undefined;
+}
+
 export function getYarnBerryVersion(directory: string): string | undefined {
   let entries: string[];
   try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,13 +104,53 @@ export function getYarnBerryVersion(directory: string): string | undefined {
     return undefined;
   }
 
+  const versions: string[] = [];
   for (const entry of entries) {
     const match = /^yarn-(\d+\.\d+\.\d+.*)\.cjs$/.exec(entry);
     if (match) {
-      return match[1];
+      versions.push(match[1]);
     }
   }
-  return undefined;
+
+  if (versions.length === 0) {
+    return undefined;
+  }
+
+  versions.sort(compareSemverDesc);
+  return versions[0];
+}
+
+function compareSemverDesc(a: string, b: string): number {
+  const av = parseSemver(a);
+  const bv = parseSemver(b);
+
+  if (av.major !== bv.major) {
+    return bv.major - av.major;
+  }
+  if (av.minor !== bv.minor) {
+    return bv.minor - av.minor;
+  }
+  if (av.patch !== bv.patch) {
+    return bv.patch - av.patch;
+  }
+
+  // Stable releases rank higher than any prerelease of the same X.Y.Z.
+  if (!av.prerelease && bv.prerelease) {
+    return -1;
+  }
+  if (av.prerelease && !bv.prerelease) {
+    return 1;
+  }
+  if (av.prerelease && bv.prerelease) {
+    return bv.prerelease.localeCompare(av.prerelease);
+  }
+  return 0;
+}
+
+function parseSemver(version: string): { major: number; minor: number; patch: number; prerelease: string | undefined } {
+  const [core, prerelease] = version.split('-', 2);
+  const [major, minor, patch] = core.split('.').map(Number);
+  return { major: major ?? 0, minor: minor ?? 0, patch: patch ?? 0, prerelease };
 }
 
 export function getLockFilePath(directory: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,9 +142,40 @@ function compareSemverDesc(a: string, b: string): number {
     return 1;
   }
   if (av.prerelease && bv.prerelease) {
-    return bv.prerelease.localeCompare(av.prerelease);
+    return -comparePrereleaseAsc(av.prerelease, bv.prerelease);
   }
   return 0;
+}
+
+// Compare prerelease identifiers per semver §11: split on '.', compare
+// all-numeric identifiers numerically, numeric < alphanumeric, more
+// identifiers > fewer when preceding identifiers are equal.
+function comparePrereleaseAsc(a: string, b: string): number {
+  const aParts = a.split('.');
+  const bParts = b.split('.');
+  const len = Math.min(aParts.length, bParts.length);
+
+  for (let i = 0; i < len; i++) {
+    const ap = aParts[i];
+    const bp = bParts[i];
+    const aIsNum = /^\d+$/.test(ap);
+    const bIsNum = /^\d+$/.test(bp);
+
+    if (aIsNum && bIsNum) {
+      const diff = Number(ap) - Number(bp);
+      if (diff !== 0) {
+        return diff;
+      }
+    } else if (aIsNum !== bIsNum) {
+      return aIsNum ? -1 : 1;
+    } else {
+      const cmp = ap.localeCompare(bp);
+      if (cmp !== 0) {
+        return cmp;
+      }
+    }
+  }
+  return aParts.length - bParts.length;
 }
 
 function parseSemver(version: string): { major: number; minor: number; patch: number; prerelease: string | undefined } {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { PackageManager } from './types';
 import { LOCK_FILE_NAMES } from './constants';
 
@@ -60,6 +60,23 @@ export function parsePnpmVersionFromModulesYaml(contents: string): string | unde
     return undefined;
   }
   return match[1];
+}
+
+export function getYarnBerryVersion(directory: string): string | undefined {
+  let entries: string[];
+  try {
+    entries = readdirSync(path.join(directory, '.yarn', 'releases'));
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    const match = /^yarn-(\d+\.\d+\.\d+.*)\.cjs$/.exec(entry);
+    if (match) {
+      return match[1];
+    }
+  }
+  return undefined;
 }
 
 export function getLockFilePath(directory: string) {

--- a/test/fixtures/install-state-vs-lockfile-conflict/node_modules/.modules.yaml
+++ b/test/fixtures/install-state-vs-lockfile-conflict/node_modules/.modules.yaml
@@ -1,0 +1,4 @@
+layoutVersion: 5
+packageManager: pnpm@8.6.0
+storeDir: /home/user/.local/share/pnpm/store/v3
+virtualStoreDir: .pnpm

--- a/test/fixtures/install-state-vs-lockfile-conflict/package-lock.json
+++ b/test/fixtures/install-state-vs-lockfile-conflict/package-lock.json
@@ -1,0 +1,7 @@
+{
+  "name": "install-state-vs-lockfile-conflict",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/test/fixtures/install-state-vs-lockfile-conflict/package.json
+++ b/test/fixtures/install-state-vs-lockfile-conflict/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "install-state-vs-lockfile-conflict",
+  "version": "1.0.0"
+}

--- a/test/fixtures/npm-installed-project/node_modules/.package-lock.json
+++ b/test/fixtures/npm-installed-project/node_modules/.package-lock.json
@@ -1,0 +1,7 @@
+{
+  "name": "npm-installed-project",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/test/fixtures/npm-installed-project/package.json
+++ b/test/fixtures/npm-installed-project/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "npm-installed-project",
+  "version": "1.0.0"
+}

--- a/test/fixtures/pnpm-installed-project/node_modules/.modules.yaml
+++ b/test/fixtures/pnpm-installed-project/node_modules/.modules.yaml
@@ -1,0 +1,18 @@
+hoistPattern:
+  - '*'
+hoistedDependencies: {}
+included:
+  dependencies: true
+  devDependencies: true
+  optionalDependencies: true
+layoutVersion: 5
+packageManager: pnpm@8.6.0
+pendingBuilds: []
+publicHoistPattern:
+  - '*eslint*'
+  - '*prettier*'
+registries:
+  default: https://registry.npmjs.org/
+skipped: []
+storeDir: /home/user/.local/share/pnpm/store/v3
+virtualStoreDir: .pnpm

--- a/test/fixtures/pnpm-installed-project/package.json
+++ b/test/fixtures/pnpm-installed-project/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pnpm-installed-project",
+  "version": "1.0.0"
+}

--- a/test/fixtures/yarn-berry-pnp-project/.pnp.cjs
+++ b/test/fixtures/yarn-berry-pnp-project/.pnp.cjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+// Stub PnP runtime for fixture purposes. Real .pnp.cjs is a generated bundle.

--- a/test/fixtures/yarn-berry-pnp-project/.yarn/releases/yarn-4.0.2.cjs
+++ b/test/fixtures/yarn-berry-pnp-project/.yarn/releases/yarn-4.0.2.cjs
@@ -1,0 +1,1 @@
+// Stub yarn release binary for fixture purposes. Real file is the bundled yarn CLI.

--- a/test/fixtures/yarn-berry-pnp-project/package.json
+++ b/test/fixtures/yarn-berry-pnp-project/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "yarn-berry-pnp-project",
+  "version": "1.0.0"
+}

--- a/test/fixtures/yarn-classic-installed-project/node_modules/.yarn-integrity
+++ b/test/fixtures/yarn-classic-installed-project/node_modules/.yarn-integrity
@@ -1,0 +1,10 @@
+{
+  "systemParams": "darwin-x64-93",
+  "modulesFolders": ["node_modules"],
+  "flags": [],
+  "linkedModules": [],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}

--- a/test/fixtures/yarn-classic-installed-project/package.json
+++ b/test/fixtures/yarn-classic-installed-project/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "yarn-classic-installed-project",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
## Summary

- Adds a new `installState` detection strategy that inspects the metadata each package manager writes during install: `node_modules/.modules.yaml` (pnpm, with version), `node_modules/.yarn-state.yml` or `.pnp.cjs` (yarn berry; version recovered from `.yarn/releases/yarn-*.cjs`), `node_modules/.yarn-integrity` (yarn classic), `node_modules/.package-lock.json` (npm).
- Promotes `installState` above `lockFile` in the default strategy order. Installed state on disk is a stronger signal than a lockfile that can lag behind a manager switch. Callers wanting the previous behavior can pass `strategies` explicitly.
- Surfaces the new name in the CLI (`--strategies installState`) and documents it in the README.

Zero new runtime dependencies — `.modules.yaml` is parsed with a single regex for the one field we need, and `.yarn/releases/yarn-X.Y.Z.cjs` provides yarn berry version via the filename.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test -- --run` (60 tests, 26 new)
- [x] `npm run build`
- [x] Manual CLI smoke: `node dist/cli.js --working-dir test/fixtures/pnpm-installed-project --strategies installState` → pnpm 8.6.0
- [x] Manual CLI smoke (default order): `node dist/cli.js --working-dir test/fixtures/install-state-vs-lockfile-conflict` → pnpm wins over `package-lock.json`
- [x] Manual CLI smoke (yarn berry): `node dist/cli.js --working-dir test/fixtures/yarn-berry-pnp-project` → yarn 4.0.2 with `agent: yarnBerry`
- [x] Manual CLI smoke (this repo): `node dist/cli.js --strategies installState` → npm