### PR TITLE
ci: lock down stage to npm-publish env

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    environment: npm-publish
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Gates staged releases to npm-publish env